### PR TITLE
Make Integration scripts work with Sandstorm

### DIFF
--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -108,6 +108,7 @@ const myCommand :Spk.Manifest.Command = (
 		(key = "SANDSTORM", value = "1"),
 		(key = "Statistics_reporting", value = "false"),
 		(key = "Accounts_AllowUserAvatarChange", value = "false"),
-		(key = "Accounts_AllowUserProfileChange", value = "false")
+		(key = "Accounts_AllowUserProfileChange", value = "false"),
+		(key = "BABEL_CACHE_DIR", value = "/var/babel_cache")
 	]
 );


### PR DESCRIPTION
Fixing #6339 - Integrations with scripts do not work in sandstorm

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6339

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Adding environment variable for sandstorm deployments. Set babel_cache_dir to a folder inside sandstorm which is writeable (everything inside /var). This solution is based on the proposal by @graywolf336. After applying this patch, this should not happen anymore inside sandstorm:
<img width="1152" alt="screen shot 2017-03-13 at 11 16 23" src="https://cloud.githubusercontent.com/assets/11456790/23871107/59a36588-0829-11e7-8569-350717b889c7.png">
